### PR TITLE
Fix EEPROM issues for Keymap Config

### DIFF
--- a/tmk_core/common/eeconfig.c
+++ b/tmk_core/common/eeconfig.c
@@ -39,7 +39,8 @@ void eeconfig_init_quantum(void) {
   eeprom_update_byte(EECONFIG_DEBUG,          0);
   eeprom_update_byte(EECONFIG_DEFAULT_LAYER,  0);
   default_layer_state = 0;
-  eeprom_update_byte(EECONFIG_KEYMAP,         0);
+  eeprom_update_byte(EECONFIG_KEYMAP_LOWER_BYTE, 0);
+  eeprom_update_byte(EECONFIG_KEYMAP_UPPER_BYTE, 0);
   eeprom_update_byte(EECONFIG_MOUSEKEY_ACCEL, 0);
   eeprom_update_byte(EECONFIG_BACKLIGHT,      0);
   eeprom_update_byte(EECONFIG_AUDIO,             0xFF); // On by default
@@ -127,12 +128,17 @@ void eeconfig_update_default_layer(uint8_t val) { eeprom_update_byte(EECONFIG_DE
  *
  * FIXME: needs doc
  */
-uint8_t eeconfig_read_keymap(void)      { return eeprom_read_byte(EECONFIG_KEYMAP); }
+uint16_t eeconfig_read_keymap(void) {
+    return ( eeprom_read_byte(EECONFIG_KEYMAP_LOWER_BYTE) | (eeprom_read_byte(EECONFIG_KEYMAP_UPPER_BYTE) << 8) );
+}
 /** \brief eeconfig update keymap
  *
  * FIXME: needs doc
  */
-void eeconfig_update_keymap(uint8_t val) { eeprom_update_byte(EECONFIG_KEYMAP, val); }
+void eeconfig_update_keymap(uint16_t val) {
+    eeprom_update_byte(EECONFIG_KEYMAP_LOWER_BYTE, val & 0xFF);
+    eeprom_update_byte(EECONFIG_KEYMAP_UPPER_BYTE, ( val >> 8 ) & 0xFF );
+}
 
 /** \brief eeconfig read backlight
  *

--- a/tmk_core/common/eeconfig.h
+++ b/tmk_core/common/eeconfig.h
@@ -45,7 +45,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define EECONFIG_HAPTIC                            (uint32_t *)24
 #define EECONFIG_RGB_MATRIX                        (uint32_t *)28
 #define EECONFIG_RGB_MATRIX_SPEED                   (uint8_t *)32
-
+// TODO: Combine these into a single word and single block of EEPROM
+#define EECONFIG_KEYMAP_UPPER_BYTE                  (uint8_t *)33
 /* debug bit */
 #define EECONFIG_DEBUG_ENABLE                       (1<<0)
 #define EECONFIG_DEBUG_MATRIX                       (1<<1)
@@ -62,6 +63,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define EECONFIG_KEYMAP_SWAP_BACKSLASH_BACKSPACE    (1<<6)
 #define EECONFIG_KEYMAP_NKRO                        (1<<7)
 
+#define EECONFIG_KEYMAP_LOWER_BYTE EECONFIG_KEYMAP
 
 bool eeconfig_is_enabled(void);
 bool eeconfig_is_disabled(void);
@@ -81,8 +83,8 @@ void eeconfig_update_debug(uint8_t val);
 uint8_t eeconfig_read_default_layer(void);
 void eeconfig_update_default_layer(uint8_t val);
 
-uint8_t eeconfig_read_keymap(void);
-void eeconfig_update_keymap(uint8_t val);
+uint16_t eeconfig_read_keymap(void);
+void eeconfig_update_keymap(uint16_t val);
 
 #ifdef BACKLIGHT_ENABLE
 uint8_t eeconfig_read_backlight(void);


### PR DESCRIPTION
I found that the Crtl-Gui configuration wasn't actually being retained in EEPROM, when resetting or power cycling the board. 

Doing some digging .... the keymap_config_t structure uses a WORD (16 bit value), but the EECONFIG is only allocating a byte (8 bits). 

This was fun, up until now, since it was only using 8 bits.  However, adding Ctrl-GUI swapping exceeded the EEPROM allocation, and was getting truncated. 

This adds another range for the EECONFIG storage, and fixes the functions to properly read from and write to EEPROM. 